### PR TITLE
Add web login helper and fix OAuth refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ browser (often on another device when running in Docker). Authorize Picsync
 when prompted. The flow now requests the Picker API scopes so that the
 application can access your selected photos. Once authorization completes,
 the app prints the values to add to `.picsync-credentials.yaml` (use the
-`-o` option to write them directly).
+`-o` option to write them directly). Alternatively you can start a small web
+server with `picsync googlephotos loginserver` and perform the OAuth flow in a
+browser on another machine.
 
 You should add a block to this with your username/password for Nixplay.
 

--- a/cmd/picsync/googlephotos.go
+++ b/cmd/picsync/googlephotos.go
@@ -37,6 +37,14 @@ var (
 		Run:   runGooglephotosPicker,
 	}
 
+	googlephotosLoginServer = &cobra.Command{
+		Use:   "loginserver",
+		Short: "Run a small web server to handle OAuth login",
+		RunE:  runGooglephotosLoginServer,
+	}
+
+	loginListen string
+
 	listShared = false
 )
 
@@ -50,6 +58,14 @@ func init() {
 	)
 
 	googlephotosCmd.AddCommand(googlephotosLogin)
+	googlephotosLoginServer.PersistentFlags().StringVarP(
+		&loginListen,
+		"listen",
+		"l",
+		":8484",
+		"Address to listen on for web login",
+	)
+	googlephotosCmd.AddCommand(googlephotosLoginServer)
 
 	googlephotosList.PersistentFlags().BoolVar(
 		&updateCache,
@@ -108,6 +124,18 @@ func runGooglephotosLogin(cmd *cobra.Command, args []string) {
 		auth.Access.Expiry.Format(time.RFC3339),
 	)
 	writeLoginOut(toWrite)
+}
+
+func runGooglephotosLoginServer(cmd *cobra.Command, args []string) error {
+	consumerKey := viper.GetString("googlephotos.api.key")
+	if consumerKey == "" {
+		return fmt.Errorf("must provide a Google Photos API key")
+	}
+	consumerSecret := viper.GetString("googlephotos.api.secret")
+	if consumerSecret == "" {
+		return fmt.Errorf("must provide a Google Photos API secret")
+	}
+	return googlephotos.ServeLogin(consumerKey, consumerSecret, loginListen)
 }
 
 func newGooglePhotosClient(c cache.Cache) (googlephotos.Client, error) {

--- a/pkg/googlephotos/login.go
+++ b/pkg/googlephotos/login.go
@@ -3,8 +3,10 @@ package googlephotos
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
@@ -58,7 +60,12 @@ func Login(consumerKey string, consumerSecret string) (*oauth2.Token, error) {
 
 	config := newOauth2Config(consumerKey, consumerSecret, codeCatcher.CatcherURL)
 
-	fmt.Printf("Follow this link to authorize:\n%s\n\n", config.AuthCodeURL(codeCatcher.State))
+	authURL := config.AuthCodeURL(
+		codeCatcher.State,
+		oauth2.AccessTypeOffline,
+		oauth2.ApprovalForce,
+	)
+	fmt.Printf("Follow this link to authorize:\n%s\n\n", authURL)
 	code := waitForCode(codeCatcher)
 	fmt.Printf("Successfully got one-time code from OAuth2 login, exchanging for tokens\n")
 	token, err := config.Exchange(context.TODO(), code, oauth2.AccessTypeOffline)
@@ -66,4 +73,53 @@ func Login(consumerKey string, consumerSecret string) (*oauth2.Token, error) {
 		return nil, err
 	}
 	return token, nil
+}
+
+// ServeLogin runs an HTTP server that guides the user through the OAuth2 login
+// flow. It listens on listenAddr and prints the resulting credentials to stdout
+// once authorization completes.
+func ServeLogin(consumerKey, consumerSecret, listenAddr string) error {
+	state := uuid.NewString()
+
+	mux := http.NewServeMux()
+
+	var cfg *oauth2.Config
+	srv := &http.Server{Addr: listenAddr, Handler: mux}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		redirect := fmt.Sprintf("http://%s/callback", r.Host)
+		cfg = newOauth2Config(consumerKey, consumerSecret, redirect)
+		url := cfg.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
+		fmt.Fprintf(w, "<a href=%q>Login with Google</a>", url)
+	})
+
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		if r.Form.Get("state") != state {
+			http.Error(w, "state mismatch", 400)
+			return
+		}
+		code := r.Form.Get("code")
+		token, err := cfg.Exchange(r.Context(), code)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		fmt.Fprintf(w, "Login complete. You can close this window.")
+		fmt.Printf("googlephotos.access.token_type: %s\n", token.TokenType)
+		fmt.Printf("googlephotos.access.access_token: %s\n", token.AccessToken)
+		fmt.Printf("googlephotos.access.refresh_token: %s\n", token.RefreshToken)
+		fmt.Printf("googlephotos.access.expiry: %s\n", token.Expiry.Format(time.RFC3339))
+		go func() {
+			// give browser time to read message
+			time.Sleep(2 * time.Second)
+			srv.Shutdown(context.Background())
+		}()
+	})
+
+	fmt.Printf("Open http://%s in your browser to authenticate\n", listenAddr)
+	return srv.ListenAndServe()
 }


### PR DESCRIPTION
- support AccessTypeOffline for refresh tokens
- add `loginserver` command to host a simple OAuth login page
- document loginserver in README