### PR TITLE
Add public URL option for loginserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ application can access your selected photos. Once authorization completes,
 the app prints the values to add to `.picsync-credentials.yaml` (use the
 `-o` option to write them directly). Alternatively you can start a small web
 server with `picsync googlephotos loginserver` and perform the OAuth flow in a
-browser on another machine.
+browser on another machine. When using Google "Web Application" OAuth
+credentials, provide the externally accessible URL with `--public-url` so the
+redirect matches the value configured in the Google console.
 
 You should add a block to this with your username/password for Nixplay.
 

--- a/cmd/picsync/googlephotos.go
+++ b/cmd/picsync/googlephotos.go
@@ -43,7 +43,8 @@ var (
 		RunE:  runGooglephotosLoginServer,
 	}
 
-	loginListen string
+	loginListen    string
+	loginPublicURL string
 
 	listShared = false
 )
@@ -64,6 +65,12 @@ func init() {
 		"l",
 		":8484",
 		"Address to listen on for web login",
+	)
+	googlephotosLoginServer.PersistentFlags().StringVar(
+		&loginPublicURL,
+		"public-url",
+		"",
+		"External URL for OAuth redirect (required for Web Application flow)",
 	)
 	googlephotosCmd.AddCommand(googlephotosLoginServer)
 
@@ -135,7 +142,7 @@ func runGooglephotosLoginServer(cmd *cobra.Command, args []string) error {
 	if consumerSecret == "" {
 		return fmt.Errorf("must provide a Google Photos API secret")
 	}
-	return googlephotos.ServeLogin(consumerKey, consumerSecret, loginListen)
+	return googlephotos.ServeLogin(consumerKey, consumerSecret, loginListen, loginPublicURL)
 }
 
 func newGooglePhotosClient(c cache.Cache) (googlephotos.Client, error) {

--- a/pkg/googlephotos/login.go
+++ b/pkg/googlephotos/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -78,7 +79,7 @@ func Login(consumerKey string, consumerSecret string) (*oauth2.Token, error) {
 // ServeLogin runs an HTTP server that guides the user through the OAuth2 login
 // flow. It listens on listenAddr and prints the resulting credentials to stdout
 // once authorization completes.
-func ServeLogin(consumerKey, consumerSecret, listenAddr string) error {
+func ServeLogin(consumerKey, consumerSecret, listenAddr, publicURL string) error {
 	state := uuid.NewString()
 
 	mux := http.NewServeMux()
@@ -86,9 +87,16 @@ func ServeLogin(consumerKey, consumerSecret, listenAddr string) error {
 	var cfg *oauth2.Config
 	srv := &http.Server{Addr: listenAddr, Handler: mux}
 
+	redirectBase := publicURL
+	if redirectBase == "" {
+		redirectBase = fmt.Sprintf("http://%s", listenAddr)
+	}
+
+	redirectURL := fmt.Sprintf("%s/callback", strings.TrimRight(redirectBase, "/"))
+
+	cfg = newOauth2Config(consumerKey, consumerSecret, redirectURL)
+
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		redirect := fmt.Sprintf("http://%s/callback", r.Host)
-		cfg = newOauth2Config(consumerKey, consumerSecret, redirect)
 		url := cfg.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
 		fmt.Fprintf(w, "<a href=%q>Login with Google</a>", url)
 	})


### PR DESCRIPTION
- support OAuth web application flow by passing a public URL to `loginserver`